### PR TITLE
Produto request: Removido campos id e imagem do body do request, Clie…

### DIFF
--- a/src/main/java/br/com/fiap/techchallenge/lanchonete/adapters/web/models/ClienteRequest.java
+++ b/src/main/java/br/com/fiap/techchallenge/lanchonete/adapters/web/models/ClienteRequest.java
@@ -1,9 +1,17 @@
 package br.com.fiap.techchallenge.lanchonete.adapters.web.models;
 
 import br.com.fiap.techchallenge.lanchonete.core.domain.models.ClienteIn;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class ClienteRequest extends ClienteIn {
+
     public ClienteRequest(Long id, String nome, String cpf, String email) {
         super(id, nome, cpf, email);
+    }
+
+    @Override
+    @JsonIgnore
+    public Long getId() {
+        return super.getId();
     }
 }

--- a/src/main/java/br/com/fiap/techchallenge/lanchonete/adapters/web/models/ProdutoRequest.java
+++ b/src/main/java/br/com/fiap/techchallenge/lanchonete/adapters/web/models/ProdutoRequest.java
@@ -2,6 +2,7 @@ package br.com.fiap.techchallenge.lanchonete.adapters.web.models;
 
 import br.com.fiap.techchallenge.lanchonete.core.domain.models.ProdutoIn;
 import br.com.fiap.techchallenge.lanchonete.core.domain.models.enums.CategoriaEnum;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -23,6 +24,7 @@ public class ProdutoRequest extends ProdutoIn {
     }
 
     @Override
+    @JsonIgnore
     public Long getId() {
         return super.getId();
     }
@@ -53,6 +55,7 @@ public class ProdutoRequest extends ProdutoIn {
     }
 
     @Override
+    @JsonIgnore
     public byte[] getImagem() {
         return super.getImagem();
     }


### PR DESCRIPTION
Este PR tem como propostas remover os campos não utilizados do swagger nos requests (create, update) de Cliente e Produto. 

# Cliente

Nos requests de create e update cliente foi removido o campo id, pois no create ele é gerado pelo banco de dados e no update ele está no path da url

Como estava:
![insert cliente com id](https://github.com/diego-jo/tech-challenge/assets/5169539/c1c1fc23-52d1-40bc-af2d-73fc246370f9)

Como ficou:
![Insert cliente sem id](https://github.com/diego-jo/tech-challenge/assets/5169539/88d956b1-200e-4ffc-ad8e-e30e9386836a)


# Produto

Nos requests decreate e update de produto o id foi removido pelos mesmos motivos citados nas alterações de cliente e a imagem foi removida, pois temos um endpoint específico para o envio da mesma.

![patch-produto-sem-image-e-id](https://github.com/diego-jo/tech-challenge/assets/5169539/96a39f31-33db-4ca3-8114-771a703248ea)
![request-produto-sem-imagem-e-id](https://github.com/diego-jo/tech-challenge/assets/5169539/729e2e01-34b9-4c2d-830c-2fb684fdde35)
 

