### PR TITLE
Removendo o status pago do pedido e alterando o status do pedido para…

### DIFF
--- a/src/main/java/br/com/fiap/techchallenge/lanchonete/core/domain/entities/enums/StatusPedidoEnum.java
+++ b/src/main/java/br/com/fiap/techchallenge/lanchonete/core/domain/entities/enums/StatusPedidoEnum.java
@@ -6,7 +6,6 @@ import java.util.stream.Stream;
 
 public enum StatusPedidoEnum {
     PENDENTE_DE_PAGAMENTO("Aguardando Pagamento"),
-    PAGO("Pago"),
     RECEBIDO("Recebido"),
     EM_PREPARACAO("Em preparação"),
     PRONTO("Pronto"),

--- a/src/main/java/br/com/fiap/techchallenge/lanchonete/core/usecases/cobranca/AtualizaStatusCobrancaUseCase.java
+++ b/src/main/java/br/com/fiap/techchallenge/lanchonete/core/usecases/cobranca/AtualizaStatusCobrancaUseCase.java
@@ -42,7 +42,7 @@ public class AtualizaStatusCobrancaUseCase implements AtualizaStatusCobrancaInpu
 
     private StatusPedidoEnum getStatusPedido(StatusCobrancaEnum statusCobranca) {
         return switch(statusCobranca) {
-            case PAGO -> StatusPedidoEnum.PAGO;
+            case PAGO -> StatusPedidoEnum.RECEBIDO;
             case CANCELADO -> StatusPedidoEnum.CANCELADO;
             default -> null;
         };


### PR DESCRIPTION
Após a última implementação do lista de produção de pedidos achei melhor remover o status de pago do pedido e deixar apenas na cobrança vinculada a ele. 
Agora quando a cobrança passa para o status de pago o pedido muda para o status de RECEBIDO.